### PR TITLE
Support resizing of menu

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -121,8 +121,6 @@ WHERE path IS NOT NULL AND name LIKE ?;
 
 
 local ZoteroBrowser = Menu:extend{
-    width = Screen:getWidth(),
-    height = Screen:getHeight(),
     no_title = false,
     is_borderless = true,
     is_popout = false,


### PR DESCRIPTION
Don't provide width and height to Menu to allow resizing on platforms that support it.

Tested on sway using SDL's wayland backend.