### PR TITLE
Stelzch dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,31 @@ This addon for [KOReader](https://github.com/koreader/koreader) allows you to vi
 <div align="center"><img width="600" alt="Screenshot of this plugin displaying a list of papers alongside a search button" src="https://raw.githubusercontent.com/stelzch/screencasts/main/zotero-koplugin-screenshot.png"></div>
 
 ## Features
-* Synchronize via Web API
-* Display collections, navigate to sub-collections
-* Download & open attached PDF files
+* Synchronization via Zotero Web API
+* Open attached PDF/EPUB/HTML files
+* Upload KOReader annotations to Zotero
+* Automatically download items of selected collections at sync time
 * Supports WebDAV storage backend
 * Search entries by the title of the publication, name of the first author or DOI.
 
+### Limitations
 
+* Currently, this plugin _only supports uploading annotations_ made with KOReader to Zotero. Changes and deletions made either in KOReader itself or Zotero will not be synchronized.
+* Annotations are not written into the PDF file itself, meaning they are only visible in Zotero's built-in PDF reader.
 
 
 ## Installation Guide
-1. Copy the files in this repository to `<KOReader>/plugins/zotero.koplugin`
-2. Obtain an API token for your account by generating a new key in your [Zotero Settings](https://www.zotero.org/settings/keys). Note the userID and the private key.
-3. Set your credentials for Zotero either directly in KOReader or edit the configuration file as described [below](#manual-configuration).
+1. Ensure you are running the latest version of KOReader
+2. Copy the files in this repository to `<KOReader>/plugins/zotero.koplugin`
+3. Obtain an API token for your account by generating a new key in your [Zotero Settings](https://www.zotero.org/settings/keys). Note the userID and the private key.
+5. If applicable, obtain username and password for your WebDAV storage.
+6. Set your credentials for Zotero either directly in KOReader or edit the configuration file as described [below](#manual-configuration).
 
-
-### Differences to previous  versions
-In previous versions, you had to copy your entire Zotero directory to your device.
-The new version however works with the Zotero Web API and downloads attachments ad-hoc.
-If you are not interested in syncing your collection and would rather access your entire collection offline, you can take a look at version [0.1](https://github.com/stelzch/zotero.koplugin/releases/tag/0.1).
 
 ## Configuration
 
 ### WebDAV support
-If you do not want to pay Zotero for more storage, you can also store the attachments in a WebDAV folder like [Nextcloud](https://nextcloud.com).
-You can read more about how to set up WebDAV in the [Zotero manual](https://www.zotero.org/support/sync).
+If you do not want to pay Zotero for more storage, you can also store the attachments in a WebDAV folder like [Nextcloud](https://nextcloud.com).  You can read more about how to set up WebDAV in the [Zotero manual](https://www.zotero.org/support/sync).
 
 The WebDAV URL should point to a directory named zotero. If you use Nextcloud, it will look similar to this: [http://your-instance.tld/remote.php/dav/files/your-username/zotero](). It is probably a good idea to use an app password instead of your user password, so that you can easily revoke it in the security settings should you ever lose your device.
 
@@ -41,12 +41,11 @@ The WebDAV URL should point to a directory named zotero. If you use Nextcloud, i
 If you do not want to type in the account credentials on your E-Reader, you can also edit the settings file directly.
 Edit the `zotero/meta.lua` file inside the koreader directory and supply needed values:
 ```lua
--- we can read Lua syntax here!
 return {
-    ["api_key"] = "", -- API secret key
-    ["user_id"] = "", -- API user ID, should be an integer number
-    ["webdav_enabled"] = false,
-    ["webdav_url"] = "", -- URL to WebDAV zotero directory
+    ["api_key"] = "",           -- Zotero API secret key
+    ["user_id"] = "",           -- API user ID, should be an integer number
+    ["webdav_enabled"] = false, -- set to true if you use WebDAV to store attachments
+    ["webdav_url"] = "",        -- URL to WebDAV zotero directory
     ["webdav_user"] = "",
     ["webdav_password"] = "",
 }

--- a/_meta.lua
+++ b/_meta.lua
@@ -1,4 +1,5 @@
 local _ = require("gettext")
+
 return {
     name = "Zotero",
     fullname = _("Zotero"),

--- a/annotations.lua
+++ b/annotations.lua
@@ -1,0 +1,226 @@
+local Annotations = {}
+local mupdf = require("ffi/mupdf")
+local DrawContext = require("ffi/drawcontext")
+local BlitBuffer = require("ffi/blitbuffer")
+local DocSettings = require("docsettings")
+local JSON = require("json")
+local logger = require('logger')
+
+local Z2K_COLORS = {
+["#ffd400"] = "yellow",
+["#ff6666"] = "red",
+["#5fb236"] = "green",
+["#2ea8e5"] = "blue",
+["#a28ae5"] = "purple",
+["#e56eee"] = "red", -- this would be magenta, but that is not in KOreaders palette
+["#f19837"] = "orange",
+["#aaaaaa"] = "gray",
+}
+
+local K2Z_COLORS = {
+    ["red"]    = "#FF3300",
+    ["orange"] = "#FF8800",
+    ["yellow"] = "#FFFF33",
+    ["green"]  = "#00AA66",
+    ["olive"]  = "#88FF77",
+    ["cyan"]   = "#00FFEE",
+    ["blue"]   = "#0066FF",
+    ["purple"] = "#EE00FF",
+    ["gray"] = "#aaaaaa",
+}
+
+local K2Z_STYLE = {
+    ["underscore"] = "underline",
+    ["lighten"] = "highlight",
+    ["strikeout"] = "highlight",
+    ["invert"] = "highlight",
+}
+
+function Annotations.getPageDimensions(file, pages)
+    if pages == nil then
+        return {}
+    end
+
+    local result = {}
+    local dc = DrawContext.new()
+    local document = mupdf.openDocument(file)
+
+    if document == nil then
+        return nil
+    end
+
+    for pageno,v in pairs(pages) do
+        local page = document:openPage(pageno)
+
+        if page == nil then
+            document:close()
+            return nil
+        end
+        result[pageno] = {page:getSize(dc)}
+
+        page:close()
+    end
+
+    document:close()
+
+    return result
+end
+--
+-- Output the timezone-agnostic timestamp, since KOReader uses timestamps with
+-- local time.
+function Annotations.utcFromLocal(timestamp)
+    local year, month, day, hour, minute, second = string.match(timestamp,
+        "(%d%d%d%d)-(%d%d)-(%d%d) (%d%d):(%d%d):(%d%d)")
+    local time = {
+        ["year"] = year,
+        ["month"] = month,
+        ["day"] = day,
+        ["hour"] = hour,
+        ["min"] = minute,
+        ["sec"] = second
+    }
+
+    return os.date("!%Y-%m-%dT%H:%M:%SZ", os.time(time))
+end
+
+function Annotations.localFromUtc(utc_timestamp)
+    local year, month, day, hour, minute, second = string.match(utc_timestamp,
+        "(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)Z")
+    local time = {
+        ["year"] = year,
+        ["month"] = month,
+        ["day"] = day,
+        ["hour"] = hour,
+        ["min"] = minute,
+        ["sec"] = second
+    }
+
+    return os.date("%Y-%m-%d %H:%M:%S", os.time(time))
+end
+
+
+
+function Annotations.colorZoteroToKOReader(hex_code)
+
+
+end
+
+function Annotations.colorKOReaderToZotero(color_name)
+    return string.lower(BlitBuffer.HIGHLIGHT_COLORS[string.lower(color_name)])
+end
+
+function Annotations.annotationTypeKOReaderToZotero(type)
+    return K2Z_STYLE[string.lower(type)]
+end
+
+function Annotations.convertKOReaderToZotero(annotation, page_height, parent_key)
+    local date = Annotations.utcFromLocal(annotation.datetime)
+    local color = Annotations.colorKOReaderToZotero(annotation.color)
+    local type = Annotations.annotationTypeKOReaderToZotero(annotation.drawer)
+    local rects = {}
+
+    -- Coordinate systems of KOReader and Zotero are flipped. On KOReader, the
+    -- y-axis extends towards the bottom whereas on Zotero the y-axis extends
+    -- towards the bottom.
+    -- Therefore, we need to transform coordinates before uploading them to Zotero
+    for _, pbox in ipairs(annotation.pboxes) do
+        local x1 = pbox.x
+        local y1 = page_height - pbox.y - pbox.h
+        local x2 = pbox.x + pbox.w
+        local y2 = y1 + pbox.h
+
+        table.insert(rects, {x1, y1, x2, y2})
+    end
+
+
+    return {
+        ["itemType"] = "annotation",
+        ["parentItem"] = parent_key,
+        ["annotationType"] = type,
+        ["annotationComment"] = annotation.note or "",
+        ["annotationText"] = annotation.text or "",
+        ["annotationColor"] = color,
+        ["annotationPageLabel"] = tostring(annotation.page),
+        ["annotationSortIndex"] = "00000|000000|00000",
+        ["annotationPosition"] = JSON.encode({
+            ["pageIndex"] = annotation.pageno - 1,
+            ["rects"] = rects,
+        }),
+--        ["tags"] = {},
+        ["dateAdded"] = date,
+        ["dateModified"] = date
+    }
+
+end
+
+
+-- Create annotations for a single document using creation_callback.
+function Annotations.createAnnotations(file_path, key, creation_callback)
+    local doc_settings = DocSettings:open(file_path)
+    if doc_settings.data == nil
+        or doc_settings.data["annotations"] == nil
+        or #doc_settings.data["annotations"] == 0 then
+        return
+    end
+
+    local k_annotations_modified = false
+    local k_annotations = doc_settings.data["annotations"]
+    local z_annotations = {}
+    local pages = {}
+
+    -- the following associative array maps from indices of k_annotations to z_annotations.
+    -- This is necessary because not all annotations necessitate a creation event, since some might
+    -- have been created in a prevous sync.
+    local index_map = {}
+
+    -- gather page numbers beforehand so that we may determine page sizes in a
+    -- single go
+    for i=1,#k_annotations do
+        local pageno = k_annotations[i].pageno
+        pages[pageno] = true
+    end
+
+    local page_dimensions = Annotations.getPageDimensions(file_path, pages)
+
+    if page_dimensions == nil then
+        logger.err(("Zotero: Skipping '%s' because page dimensions can not be determined. relevant pages where %s"):format(file_path, JSON.encode(pages)))
+        return nil
+    end
+
+    for i = 1,#k_annotations do
+        if k_annotations[i].zoteroKey == nil then
+            local pageno = k_annotations[i].pageno
+            local page_height = page_dimensions[pageno][2]
+            local a = Annotations.convertKOReaderToZotero(k_annotations[i], page_height, key)
+            table.insert(z_annotations, a)
+            index_map[#z_annotations] = i -- keep track of index
+        end
+    end
+
+    if #z_annotations == 0 then
+        return nil, nil
+    end
+    logger.dbg(("Zotero: creating annotations for %s:\n%s"):format(file_path, JSON.encode(z_annotations)))
+    local created_items, e = creation_callback(z_annotations)
+
+    if created_items == nil then
+        return nil, e
+    end
+
+    for k,v in pairs(created_items) do
+        if v.key ~= nil then
+            local k_index = index_map[k]
+            assert(k_index ~= nil)
+            k_annotations[k_index].zoteroKey = v.key
+            k_annotations_modified = true
+        end
+    end
+
+    if k_annotations_modified then
+        doc_settings:flush()
+    end
+
+    return nil, nil
+end
+
+return Annotations

--- a/annotations.lua
+++ b/annotations.lua
@@ -36,6 +36,8 @@ local K2Z_STYLE = {
     ["invert"] = "highlight",
 }
 
+local defaultColor = K2Z_COLORS["gray"]
+
 function Annotations.getPageDimensions(file, pages)
     if pages == nil then
         return {}
@@ -115,7 +117,8 @@ end
 
 function Annotations.convertKOReaderToZotero(annotation, page_height, parent_key)
     local date = Annotations.utcFromLocal(annotation.datetime)
-    local color = Annotations.colorKOReaderToZotero(annotation.color)
+    local color = defaultColor
+    if annotation.color ~= nil then color = Annotations.colorKOReaderToZotero(annotation.color) end
     local type = Annotations.annotationTypeKOReaderToZotero(annotation.drawer)
     local rects = {}
 

--- a/main.lua
+++ b/main.lua
@@ -15,6 +15,7 @@ local Geom = require("ui/geometry")
 local _ = require("gettext")
 local ZoteroAPI = require("zoteroapi")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
+local BaseUtil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 
 
@@ -102,7 +103,7 @@ function ZoteroBrowser:onMenuSelect(item)
                 UIManager:close(self.download_dialog)
                 local ReaderUI = require("apps/reader/readerui")
                 self.close_callback()
-                ReaderUI:showReader(full_path)
+                ReaderUI:showReader(BaseUtil.realpath(full_path))
             end
         end)
         UIManager:show(self.download_dialog)

--- a/spec/zoteroapi_spec.lua
+++ b/spec/zoteroapi_spec.lua
@@ -1,0 +1,29 @@
+describe("Zotero API Client", function()
+    --local orig_path = package.path
+    --local API_KEY = os.getenv("ZOTERO_API_KEY")
+    --local USER_ID = os.getenv("ZOTERO_USER_ID")
+    --assert.truthy(API_KEY)
+    --assert.truthy(USER_ID)
+
+    --package.path = "plugins/zotero.koplugin/?.lua;" .. package.path
+    --require("commonrequire")
+    --local JSON = require("json")
+    --local ZoteroAPI = require("zoteroapi")
+    --package.path = orig_path
+
+    --ZoteroAPI.init("/tmp/zoteroplugin")
+    --ZoteroAPI.setAPIKey(API_KEY)
+    --ZoteroAPI.setUserID(USER_ID)
+
+    --local headers = {
+    --    ["Zotero-API-Key"] = API_KEY,
+    --    ["Zotero-API-Version"] = "3"
+    --}
+
+    it("can execute tests", function()
+        assert.is_true(true)
+    end)
+
+
+end)
+

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -1,6 +1,5 @@
 local BaseUtil = require("ffi/util")
 local LuaSettings = require("luasettings")
-local http = require("socket.http")
 local https = require("ssl.https")
 local ltn12 = require("ltn12")
 local JSON = require("json")
@@ -691,15 +690,16 @@ function API.downloadWebDAV(key, targetDir, targetPath)
     local zip_cmd = "unzip -qq '" .. zipPath .. "' -d '" .. targetDir .. "'"
     logger.dbg("Zotero: unzipping with " .. zip_cmd)
     local zip_result = os.execute(zip_cmd)
-    if zip_result then
-        return targetPath
-    else
-        return nil, "Unzipping failed"
-    end
 
     local remove_result, e, ecode = os.remove(zipPath)
     if remove_result == nil then
         logger.err(("Zotero: failed to remove zip file %s, error %s"):format(zipPath, e))
+    end
+
+    if zip_result then
+        return targetPath
+    else
+        return nil, "Unzipping failed"
     end
 end
 

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -793,12 +793,16 @@ function API.syncItemAnnotations(itemKey)
                 --print("KOReader annotation imported from Zotero ", ann.zoteroKey)
                 localZotAnn[ann.zoteroKey] = idx
             else
-                print("Additional KOReader annotation", ann.text)
-                -- make 'fake' sort key
-                koreaderAnnotations[idx].zoteroSortIndex = "0002"
-                print(string.format("%05d|%05d|%05d", ann.page-1, idx,100))
-                table.insert(localKORAnn, idx)
-                localMods = localMods + 1
+                if ann.drawer ~= nil then -- it's a note or highlight
+                    print("Additional KOReader annotation", ann.text)
+                    -- make 'fake' sort key
+                    koreaderAnnotations[idx].zoteroSortIndex = "0002"
+                    print(string.format("%05d|%05d|%05d", ann.page-1, idx, math.floor(ann.pos0.x)))
+                    table.insert(localKORAnn, idx)
+                    localMods = localMods + 1
+                else -- it's a bookmark (or even s/t else?)
+                    print("Ignoring bookmark", ann.text)
+                end
             end
         end
         -- Iterate over local Zotero annotations to check whether they have been changed

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -557,6 +557,7 @@ local function zotero2KoreaderAnnotation(annotation, pageHeightinPoints)
             ["pos1"] = pos1,
             ["text"] = annotation.data.annotationText,
             ["zoteroKey"] = annotation.key,
+            ["zoteroSortIndex"] = annotation.data.annotationSortIndex,
             ["zoteroVersion"] = annotation.version,
         }
     -- KOReader seems to use the presence of the "note" field to distinguish between "highlight" and "note"
@@ -733,10 +734,6 @@ function API.syncItemAnnotations(itemKey)
         end
     end
     
-    --local comparator = function(a,b)
-    --    return (a["annotationSortIndex"] < b["annotationSortIndex"])
-    --end
-    --table.sort(zoteroAnnotations, comparator)
 
     -- Add them to the docsettings if they are not there yet, or update them if
     -- they already exist but are outdated
@@ -791,13 +788,16 @@ function API.syncItemAnnotations(itemKey)
         local pageDims = document:getNativePageDimensions(1)
         print("Page dimensions: ", JSON.encode(pageDims))
         document:close()
---        local i = 1
+
         for annotationKey, annotation in pairs(zoteroAnnotations) do
             table.insert(koAnnotations, zotero2KoreaderAnnotation(annotation, pageDims.h))
---          koAnnotations[i] = zotero2KoreaderAnnotation(annotation, pageDims.h)
---          i = i + 1
         end
---      print(i, " KOreader from zotero annotation")
+
+        local comparator = function(a,b)
+            return (a["zoteroSortIndex"] < b["zoteroSortIndex"])
+        end
+        table.sort(koAnnotations, comparator)
+
 --      print(JSON.encode(koAnnotations))    
 --  Not sure this is still needed. But useful for debugging:
         local settings_path = BaseUtil.joinPath(fileDir, "metadata.zotero.lua")

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -577,7 +577,7 @@ end
 
 function API.displaySearchResults(query)
     print("displaySearchResults for " .. query)
-    local queryRegex = ".*" .. string.gsub(query, " ", ".*") .. ".*"
+    local queryRegex = ".*" .. string.gsub(string.lower(query), " ", ".*") .. ".*"
     print("Searching for " .. queryRegex)
     -- Careful: linear search. Can be optimized quite a bit!
     local items = API.getItems()
@@ -596,7 +596,7 @@ function API.displaySearchResults(query)
                     name = name .. " - " .. parentItem.data.DOI
                 end
 
-                if string.match(name, queryRegex) then
+                if string.match(string.lower(name), queryRegex) then
                     table.insert(results, {
                         ["key"] = k,
                         ["text"] = name

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -561,7 +561,7 @@ local function newKoreaderAnnotation(annotation, pageHeightinPoints)
             --["text"] = annotation.data.annotationComment,
         --},
         ["highlight"] = {
-            ["datetime"] = annotation.data.dateModified,
+            ["datetime"] = string.sub(string.gsub(annotation.data.dateModified, "T", " "), 1, -2),
             ["drawer"] = "lighten",
             ["page"] = page,
             ["pboxes"] = rects,

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -63,6 +63,17 @@ local function file_slurp(path)
     return content
 end
 
+local function keysToString(array) 
+	
+	local s = ''
+	
+	for k, v in pairs(array) do
+		s = s..k..','
+	end
+	if s ~= '' then s = string.sub(s,1,-2) end  -- remove the final comma
+	return s
+end
+
 function API.cutDecimalPlaces(x, num_places)
     local fac = 10^num_places
     return math.floor(x * fac) / fac
@@ -247,6 +258,21 @@ function API.verifyResponse(r, c)
     return nil
 end
 
+function API.verifyKeyAccess()
+    local e, api_key, user_id = API.ensureKeyAndID()
+    local headers = API.getHeaders(api_key)
+    local page_data = {}
+    local r, c, h = https.request {
+        method = "GET",
+        url = "https://api.zotero.org/keys/current",
+        headers = headers,
+        sink = ltn12.sink.table(page_data)
+    }
+    local e = API.verifyResponse(r, c)
+--    local resp = JSON.decode(page_data)
+    print(page_data[1])
+end
+    
 function API.fetchCollectionSize(collection_url, headers)
     print("Determining size of '" .. collection_url .. "'")
     local r, c, h = https.request {
@@ -810,6 +836,9 @@ function API.syncItemAnnotations(itemKey, annotation_callback)
             updateNeeded = false
         end
     end
+    
+    --print("Keys: \""..keysToString(zoteroItems).."\"")
+    API.verifyKeyAccess()
     
     -- Add them to the docsettings 
     -- NOTE: Currently annotations that are not already there just get overwritten

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -21,7 +21,8 @@ local sha2 = require("ffi/sha2")
 local API = {}
 
 local SUPPORTED_MEDIA_TYPES = {
-    [1] = "application/pdf"
+    [1] = "application/pdf",
+--    [2] = "application/epub+zip"
 }
 
 local function joinTables(target, source)

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -928,7 +928,7 @@ function API.createItems(items)
             return created_items, "Error: failed to parse JSON in response to annotation creation request"
         end
 
-        local new_library_version = response_headers["Last-Modified-Version"]
+        local new_library_version = response_headers["last-modified-version"]
         if new_library_version ~= nil then
             API.setLibraryVersion(new_library_version)
         else

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -147,7 +147,7 @@ function API.checkWebDAV()
     local pass = API.getWebDAVPassword()
     local headers = API.getWebDAVHeaders()
 
-    local b, c, h = http.request {
+    local b, c, h = https.request {
         url = url,
         method = "PROPFIND",
         headers = headers
@@ -244,7 +244,7 @@ end
 
 function API.fetchCollectionSize(collection_url, headers)
     print("Determining size of '" .. collection_url .. "'")
-    local r, c, h = http.request {
+    local r, c, h = https.request {
         method = "HEAD",
         url = collection_url,
         headers = headers
@@ -284,7 +284,7 @@ function API.fetchCollectionPaginated(collection_url, headers, callback)
         print("Fetching page ", item_nr, page_url)
 
         local page_data = {}
-        local r, c, h = http.request {
+        local r, c, h = https.request {
             method = "GET",
             url = page_url,
             headers = headers,
@@ -444,10 +444,10 @@ function API.downloadAndGetPath(key, download_callback)
         local url = "https://api.zotero.org/users/" .. API.getUserID() .. "/items/" .. key .. "/file"
         print("Fetching " .. url)
 
-        local r, c, h = http.request {
+        local r, c, h = https.request {
             url = url,
             headers = API.getHeaders(api_key),
-            redirect = true,
+--            redirect = true,
             sink = ltn12.sink.file(io.open(targetPath, "wb"))
         }
 
@@ -473,11 +473,11 @@ function API.downloadWebDAV(key, targetDir, targetPath)
     local headers = API.getWebDAVHeaders()
     local zipPath = targetDir .. "/" .. key .. ".zip"
     print("Fetching URL " .. url)
-    local r, c, h = http.request {
+    local r, c, h = https.request {
         method = "GET",
         url = url,
         headers = headers,
-        redirect = true,
+--        redirect = true,
         sink = ltn12.sink.file(io.open(zipPath, "wb"))
     }
 

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -1,6 +1,6 @@
 local BaseUtil = require("ffi/util")
 local LuaSettings = require("luasettings")
-local http = require("socket.http")
+--local http = require("socket.http")
 local ltn12 = require("ltn12")
 local https = require("ssl.https")
 local JSON = require("json")

--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -544,16 +544,30 @@ function API.displayCollection(key)
             and table_contains(SUPPORTED_MEDIA_TYPES, item.data.contentType )
             and item.data.parentItem ~= nil then
             local parentItem = items[item.data.parentItem]
-            if parentItem ~= nil and table_contains(parentItem.data.collections, key) then
-                local author = parentItem.meta.creatorSummary or "Unknown"
-                local name = author .. " - " .. parentItem.data.title
+            if parentItem ~= nil then
+				local displayItem = false
+				if key == nil then
+					-- We are dealing with the root collection here
+					if #parentItem.data.collections == 0 then 
+					-- this entry is not part of the collection and will be shown as part of the root collection
+						displayItem = true
+					end
+				elseif table_contains(parentItem.data.collections, key) then
+					-- this entry is not part of the collection specified by key
+					displayItem = true
+				end
+			
+				if displayItem then
+					local author = parentItem.meta.creatorSummary or "Unknown"
+					local name = author .. " - " .. parentItem.data.title
 
-                table.insert(collectionItems, {
-                    ["key"] = k,
-                    ["text"] = name
-                })
-            end
-        end
+					table.insert(collectionItems, {
+						["key"] = k,
+						["text"] = name
+					})
+				end
+			end
+		end
     end
     table.sort(collectionItems, comparator)
 


### PR DESCRIPTION
Dear Christoph,

thank you very much for creating and maintaining this Zotero KOReader plugin. It's great to have a simple way to get papers onto my E-Reader.

I've just noticed that you have started to completely restructure the code in your 'dev' branch. This must have been a major effort, but moving to a SQLite database seems indeed a great way to make it more scalable!

This pull request is just to get in touch and address two quite simple issues (based on your dev branch code, but also applies to main):
- replace all http calls with https: my webdav does not let me connect using http, and zotero also really wants https...
- actually delete the zip file after a webdav download


As I thought you had abandoned this project I have been working on the code a bit myself since I discovered it a few weeks ago. E.g. I fixed some of the same things that you have already commited to your master branch a few days ago.

One thing I dealt with slightly differently are documents which are not part of a collection: I mostly use saved searches to organise my library these days, so I have loads of these documents. 
But rather than putting everything in an 'all items' folder I think it is more consistent to list them under the collections in the root folder (as this is what you do once your are in a sub-collection)

And as I have a rather large library with existing annotations I was very keen to be able to see them in your plugin (for me this is more important than synching annotations back, as the KOReader is unlikely to be my main device for dealing with Zotero for a while yet...)

I think I have a fairly complete version of this in my 'annotation' branch if you want to check this out. It's still a bit clunky and based on the pre-SQLite version, so it would be a little bit of an effort to migrate this. I would be happy to do this/help with this, but I don't want to duplicate effort here.

Let me know what you think.

Thanks again

  Jochen