### PR TITLE
Support attachments where the link mode is imported_url

### DIFF
--- a/zoteroapi.lua
+++ b/zoteroapi.lua
@@ -448,7 +448,7 @@ function API.downloadAndGetPath(key, download_callback)
         return nil, "Error: this item is a linked attachment. Linked attachments are currently unsupported."
     end
 
-    if item.data.linkMode ~= "imported_file" then
+    if item.data.linkMode ~= "imported_file" and item.data.linkMode ~= "imported_url" then
         return nil, "Error: unsupported link mode '" .. tostring(item.data.linkMode) .. "'."
     end
 


### PR DESCRIPTION
This fixes #37 , where PDF attachments that have the link mode `imported_url` were not opening.